### PR TITLE
FOLIO-3994 Use GitHub Workflows release v1

### DIFF
--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   go-lint:
-    uses: folio-org/.github/.github/workflows/go-lint.yml@master
+    uses: folio-org/.github/.github/workflows/go-lint.yml@v1
     with:
       errcheck-excludes-file: 'src/.errcheck-exclude'
       golangci-config-file: 'src/.golangci.yml'

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   go:
-    uses: folio-org/.github/.github/workflows/go.yml@master
+    uses: folio-org/.github/.github/workflows/go.yml@v1
     secrets: inherit
     with:
       docker-label-documentation: 'https://github.com/folio-org/ui-ldp/blob/master/doc/reports.md'

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,7 +11,7 @@ on:
       - 'Dockerfile'
       - 'descriptors/ModuleDescriptor-template.json'
       - 'sonar-project.properties'
-      - '.github/workflows/do-go.yml'
+      - '.github/workflows/go.yml'
     tags:
       - '[vV][0-9]+.[0-9]+.[0-9]+*'
   workflow_dispatch:


### PR DESCRIPTION
Currently that equates to https://github.com/folio-org/.github/releases/tag/v1.6.0
When a new centralised version is released, then due to our `@v1` we will automatically use the new current release. 