### PR TITLE
Replace "xxx" strings in tests with other strings

### DIFF
--- a/src/ldp-config_test.go
+++ b/src/ldp-config_test.go
@@ -48,14 +48,14 @@ func Test_handleConfig(t *testing.T) {
 		{
 			name:     "write a new config value",
 			path:     "/ldp/config/foo",
-			sendData: `{"key":"foo","tenant":"xxx","value":"{\"user\":\"abc123\"}"}`,
+			sendData: `{"key":"foo","tenant":"diku","value":"{\"user\":\"abc123\"}"}`,
 			function: handleConfigKey,
 			expected: "abc123",
 		},
 		{
 			name:     "rewrite an existing config value",
 			path:     "/ldp/config/dbinfo",
-			sendData: `{"key":"dbinfo","tenant":"xxx","value":"{\"user\":\"abc456\"}"}`,
+			sendData: `{"key":"dbinfo","tenant":"diku","value":"{\"user\":\"abc456\"}"}`,
 			function: handleConfigKey,
 			expected: "abc456",
 		},

--- a/src/reporting_test.go
+++ b/src/reporting_test.go
@@ -243,7 +243,7 @@ func Test_reportingHandlers(t *testing.T) {
 		{
 			name:     "malformed report",
 			path:     "/ldp/db/reports",
-			sendData: `xxx`,
+			sendData: `a non-JSON string`,
 			function: handleReport,
 			errorstr: "deserialize JSON",
 		},

--- a/src/server_test.go
+++ b/src/server_test.go
@@ -70,14 +70,14 @@ func runTests(t *testing.T, baseUrl string, session *ModReportingSession) {
 		},
 		{
 			name:     "create new config",
-			sendData: `{"key":"foo","tenant":"xxx","value":"{\"user\":\"abc123\"}"}`,
+			sendData: `{"key":"foo","tenant":"diku","value":"{\"user\":\"abc123\"}"}`,
 			path:     "ldp/config/foo",
 			status:   200,
 			expected: "abc123",
 		},
 		{
 			name:     "rewrite existing config",
-			sendData: `{"key":"dbinfo","tenant":"xxx","value":"{\"user\":\"abc456\"}"}`,
+			sendData: `{"key":"dbinfo","tenant":"diku","value":"{\"user\":\"abc456\"}"}`,
 			path:     "ldp/config/dbinfo",
 			status:   200,
 			expected: "abc456",


### PR DESCRIPTION
This allows grepping for "xxx" to find only TODO markers.