### PR TITLE
[MODREP-11] New Reporting DB connection for each session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Implement `/ldp/db/log`, add tests. This is in the module descriptor, so it's needed for full compatibility. Fixes MODREP-8.
 * Upgrade dependency on `crypto` library (v0.27.0 has a vulnerability). Fixes MODREP-16.
 * Add three new WSAPI endpoints (`/ldp/db/version`, `/ldp/db/updates`, `/ldp/db/processes`), write tests, update documentation. Provided interface `ldp-query` bumped from v1.3 to v1.4. Fixes MODREP-2.
+* Each new FOLIO session gets a new database connectio, causing the current DB config to be re-read. Fixes MODREP-11.
 
 ## [1.2.0](https://github.com/folio-org/mod-reporting/tree/v1.2.0) (2024-10-29)
 

--- a/src/getdbinfo_test.go
+++ b/src/getdbinfo_test.go
@@ -10,7 +10,7 @@ func Test_getDbInfo(t *testing.T) {
 	baseUrl := ts.URL
 
 	server := MakeModReportingServer(nil, nil, "")
-	session, err := NewModReportingSession(server, baseUrl, "dummyTenant")
+	session, err := NewModReportingSession(server, baseUrl, "dummyTenant", "dummyToken")
 	assert.Nil(t, err)
 
 	t.Run("info from environment", func(t *testing.T) {

--- a/src/ldp-config_test.go
+++ b/src/ldp-config_test.go
@@ -67,9 +67,9 @@ func Test_handleConfig(t *testing.T) {
 	baseUrl := ts.URL
 
 	server := MakeModReportingServer(nil, nil, "")
-	session, err := NewModReportingSession(server, baseUrl, "dummyTenant")
+	session, err := NewModReportingSession(server, baseUrl, "dummyTenant", "dummyToken")
 	assert.Nil(t, err)
-	badSession, err := NewModReportingSession(server, "x"+baseUrl, "dummyTenant")
+	badSession, err := NewModReportingSession(server, "x"+baseUrl, "dummyTenant", "dummyToken")
 	assert.Nil(t, err)
 
 	for i, test := range tests {

--- a/src/reporting_test.go
+++ b/src/reporting_test.go
@@ -380,7 +380,7 @@ func Test_reportingHandlers(t *testing.T) {
 
 	mrs, err := MakeConfiguredServer("../etc/silent.json", ".")
 	assert.Nil(t, err)
-	session, err := NewModReportingSession(mrs, baseUrl, "dummyTenant")
+	session, err := NewModReportingSession(mrs, baseUrl, "dummyTenant", "dummyToken")
 	assert.Nil(t, err)
 
 	for _, test := range tests {

--- a/src/server.go
+++ b/src/server.go
@@ -62,14 +62,14 @@ func (server *ModReportingServer) launch() error {
 }
 
 // We maintain a map of tenant:url to session
-func (server *ModReportingServer) findSession(url string, tenant string) (*ModReportingSession, error) {
-	key := tenant + ":" + url
+func (server *ModReportingServer) findSession(url string, tenant string, token string) (*ModReportingSession, error) {
+	key := tenant + ":" + url + ":" + token
 	session := server.sessions[key]
 	if session != nil {
 		return session, nil
 	}
 
-	session, err := NewModReportingSession(server, url, tenant)
+	session, err := NewModReportingSession(server, url, tenant, token)
 	if err != nil {
 		return nil, fmt.Errorf("could not create session for key '%s': %w", key, err)
 	}
@@ -133,7 +133,8 @@ This is <a href="https://github.com/folio-org/mod-reporting">mod-reporting</a>. 
 func runWithErrorHandling(w http.ResponseWriter, req *http.Request, server *ModReportingServer, f handlerFn) {
 	host := req.Header.Get("X-Okapi-Url")
 	tenant := req.Header.Get("X-Okapi-Tenant")
-	session, err := server.findSession(host, tenant)
+	token := req.Header.Get("X-Okapi-Token")
+	session, err := server.findSession(host, tenant, token)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		fmt.Fprintf(w, "could not make session: %s\n", err)

--- a/src/server_test.go
+++ b/src/server_test.go
@@ -16,9 +16,9 @@ func Test_server(t *testing.T) {
 	defer ts.Close()
 	server, err := MakeConfiguredServer("../etc/silent.json", "..")
 	assert.Nil(t, err)
-	session, err := NewModReportingSession(server, ts.URL, "t1")
+	session, err := NewModReportingSession(server, ts.URL, "t1", "dummyToken")
 	assert.Nil(t, err)
-	server.sessions[":"+ts.URL] = session
+	server.sessions[":"+ts.URL+":"] = session
 
 	go func() {
 		err = server.launch()

--- a/src/session.go
+++ b/src/session.go
@@ -20,6 +20,7 @@ type ModReportingSession struct {
 	server       *ModReportingServer // back-reference
 	url          string
 	tenant       string
+	token        string
 	folioSession foliogo.Session
 	dbConn       PgxIface
 	isMDB        bool
@@ -28,13 +29,13 @@ type ModReportingSession struct {
 /*
  * There are two valid cases:
  * 1. The url and tenant parameters are defined: we have received a request from Okapi, and the new FOLIO session should be pointed to the specified URL+tenant
- * 2. The url and tenant parameters are not defined: we have a request directly from a browser, curl command or similar, and need ot make a default FOLIO session (which will use environment variables such as OKAPI_URL)
+ * 2. The url and tenant parameters are not defined: we have a request directly from a browser, curl command or similar, and need to make a default FOLIO session (which will use environment variables such as OKAPI_URL)
  *
  * There is also one common INvalid case:
- * 3. The url parameter is not defined but the tenant parameter is. This arises when running a curl command copied from a browser session, as the url parameter is added only by Okapi. We explicitly catch this are reject it.
+ * 3. The url parameter is not defined but the tenant parameter is. This arises when running a curl command copied from a browser session, as the url parameter is added only by Okapi. We explicitly catch this and reject it.
  */
 
-func NewModReportingSession(server *ModReportingServer, url string, tenant string) (*ModReportingSession, error) {
+func NewModReportingSession(server *ModReportingServer, url string, tenant string, token string) (*ModReportingSession, error) {
 	if url == "" && tenant != "" {
 		return nil, fmt.Errorf("no URL provided with tenant: responding to a request with no X-Okapi-Url header?")
 	}
@@ -43,6 +44,7 @@ func NewModReportingSession(server *ModReportingServer, url string, tenant strin
 		server: server,
 		url:    url,
 		tenant: tenant,
+		token:  token,
 	}
 
 	if url != "" {

--- a/src/session_test.go
+++ b/src/session_test.go
@@ -14,19 +14,19 @@ func Test_session(t *testing.T) {
 	badUrl := "http://made.up.hostname.abc123:9000"
 
 	t.Run("bad URL/tenant combo", func(t *testing.T) {
-		session, err := NewModReportingSession(server, "", "diku")
+		session, err := NewModReportingSession(server, "", "diku", "dummyToken")
 		assert.Nil(t, session)
 		assert.ErrorContains(t, err, "no URL provided with tenant")
 	})
 
 	t.Run("resume Okapi session", func(t *testing.T) {
-		session, err := NewModReportingSession(server, badUrl, "")
+		session, err := NewModReportingSession(server, badUrl, "", "dummyToken")
 		assert.Nil(t, err)
 		assert.Equal(t, badUrl, session.url)
 	})
 
 	t.Run("session for command-line without env", func(t *testing.T) {
-		session, err := NewModReportingSession(server, "", "")
+		session, err := NewModReportingSession(server, "", "", "dummyToken")
 		assert.Nil(t, session)
 		assert.ErrorContains(t, err, "missing environment variables")
 	})
@@ -36,7 +36,7 @@ func Test_session(t *testing.T) {
 		os.Setenv("OKAPI_TENANT", "diku")
 		os.Setenv("OKAPI_USER", "mike")
 		os.Setenv("OKAPI_PW", "swordfish")
-		session, err := NewModReportingSession(server, "", "")
+		session, err := NewModReportingSession(server, "", "", "dummyToken")
 		assert.Nil(t, session)
 		assert.ErrorContains(t, err, "no such host")
 	})
@@ -46,7 +46,7 @@ func Test_session(t *testing.T) {
 		os.Setenv("OKAPI_TENANT", "diku")
 		os.Setenv("OKAPI_USER", "mike")
 		os.Setenv("OKAPI_PW", "swordfish")
-		session, err := NewModReportingSession(server, "", "")
+		session, err := NewModReportingSession(server, "", "", "dummyToken")
 		assert.Nil(t, err)
 		return session
 	}


### PR DESCRIPTION
Each new FOLIO session gets a new reporting-database connection, causing the current DB config to be re-read.