### PR TITLE
[MODREP-18] censor reporting-database password

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Add three new WSAPI endpoints (`/ldp/db/version`, `/ldp/db/updates`, `/ldp/db/processes`), write tests, update documentation. Provided interface `ldp-query` bumped from v1.3 to v1.4. Fixes MODREP-2.
 * Each new FOLIO session gets a new reporting-database connection, causing the current DB config to be re-read. Fixes MODREP-11.
 * Metadb-only features fail more politely (HTTP status 501) when run against LDP Classic. Fixes MODREP-17.
+* When fetching `/ldp/config/dbinfo`, the reporting-database password is replaced by `********`. Fixes MODREP-18.
 
 ## [1.2.0](https://github.com/folio-org/mod-reporting/tree/v1.2.0) (2024-10-29)
 

--- a/src/server.go
+++ b/src/server.go
@@ -99,6 +99,7 @@ This is <a href="https://github.com/folio-org/mod-reporting">mod-reporting</a>. 
   <li><a href="/admin/health">Health check</a></li>
   <li><a href="/htdocs/">Static area</a></li>
   <li><a href="/ldp/config">Legacy configuration WSAPI</a></li>
+  <li><a href="/ldp/config/dbinfo">Legacy configuration 'dbinfo'</a></li>
   <li><a href="/ldp/db/tables">List tables from reporting database</a></li>
   <li><a href="/ldp/db/columns?schema=folio_users&table=users">List columns for "users" table</a></li>
   <li><a href="/ldp/db/log">Logs</a></li>

--- a/src/server_test.go
+++ b/src/server_test.go
@@ -66,7 +66,7 @@ func runTests(t *testing.T, baseUrl string, session *ModReportingSession) {
 			name:     "get single config",
 			path:     "ldp/config/dbinfo",
 			status:   200,
-			expected: `{"key":"dbinfo","tenant":"t1","value":"{\\"pass\\":\\"pw\\",\\"url\\":\\"dummyUrl\\",\\"user\\":\\"fiona\\"}"}`,
+			expected: `{"key":"dbinfo","tenant":"t1","value":"{\\"user\\":\\"fiona\\",\\"url\\":\\"dummyUrl\\",\\"pass\\":\\"\*\*\*\*\*\*\*\*\\"}"}`,
 		},
 		{
 			name:     "create new config",


### PR DESCRIPTION
When fetching `/ldp/config/dbinfo`, or the full list of config items from `/ldp/config`, the reporting-database password is replaced by `********`.