### PR TITLE
[MODREP-21] Port can be set by `SERVER_PORT` env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Each new FOLIO session gets a new reporting-database connection, causing the current DB config to be re-read. Fixes MODREP-11.
 * Metadb-only features fail more politely (HTTP status 501) when run against LDP Classic. Fixes MODREP-17.
 * When fetching `/ldp/config/dbinfo`, the reporting-database password is replaced by `********`. Fixes MODREP-18.
+* Listening port can be set at runtime by the `SERVER_PORT` environment variable. Fixes MODREP-21.
 
 ## [1.2.0](https://github.com/folio-org/mod-reporting/tree/v1.2.0) (2024-10-29)
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ Two top-level stanzas are supported:
   * `host` is an IP address or DNS-resolvable hostname. `0.0.0.0` (all interfaces) should usually be used
   * `port` is an IP port number
 
+The specified port can be overridden at run-time by setting the `SERVER_PORT` environment variable. This is useful when invoking the service from a container whose contents (i.e. the configuration file) cannot easily be modified, but whose environment can be specified.
+
 
 ### Logging
 

--- a/src/server.go
+++ b/src/server.go
@@ -1,9 +1,11 @@
 package main
 
+import "os"
 import "fmt"
 import "net/http"
 import "time"
 import "strings"
+import "strconv"
 import "github.com/MikeTaylor/catlogger"
 
 type HTTPError struct {
@@ -62,7 +64,16 @@ func (server *ModReportingServer) Log(cat string, args ...string) {
 
 func (server *ModReportingServer) launch() error {
 	cfg := server.config
-	hostspec := cfg.Listen.Host + ":" + fmt.Sprint(cfg.Listen.Port)
+
+	var port int
+	serverPortString := os.Getenv("SERVER_PORT")
+	if serverPortString != "" {
+		port, _ = strconv.Atoi(serverPortString)
+	} else {
+		port = cfg.Listen.Port
+	}
+
+	hostspec := cfg.Listen.Host + ":" + fmt.Sprint(port)
 	server.server.Addr = hostspec
 	server.Log("listen", "listening on", hostspec)
 	err := server.server.ListenAndServe()


### PR DESCRIPTION
Listening port can be set at runtime by the `SERVER_PORT` environment variable.