### PR TITLE
MODREP-24: Smaller base images in Dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for mod-reporting
 
+## [1.3.2](https://github.com/folio-org/mod-reporting/tree/v1.3.2) (IN PROGRESS)
+
+* Smaller base images in Dockerfile. Fixes MODREP-24.
+
 ## [1.3.1](https://github.com/folio-org/mod-reporting/tree/v1.3.1) (2025-03-12)
 
 * Prevent unescape-HTML attack in `server.go` error responses. Fixes MODREP-23.

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,4 +38,5 @@ ENV LOGCAT=listen,op,curl,status,response,db,path
 #ENV REPORTING_DB_USER=miketaylor
 #ENV REPORTING_DB_PASS=swordfish
 
-ENTRYPOINT ["./mod-reporting", "config.json"]
+ENTRYPOINT ["./mod-reporting"]
+CMD ["config.json"]

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/folio-org/mod-reporting
 
-go 1.23.6
+go 1.23.6  // also update the version in Dockerfile
 
 require (
 	github.com/MikeTaylor/catlogger v0.0.2


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODREP-24

The base image for build is golang:1.23. Consider replacing it with golang:1.23-alpine.

The base image for runtime is golang:1.23. Consider replacing it with gcr.io/distroless/base:nonroot or some other smaller image.