### PR TITLE
Comment out routing for the tenant API

### DIFF
--- a/src/server.go
+++ b/src/server.go
@@ -167,8 +167,10 @@ async function enableTenant() {
 		runWithErrorHandling(w, req, server, handleUpdates)
 	} else if path == "/ldp/db/processes" {
 		runWithErrorHandling(w, req, server, handleProcesses)
+/*
 	} else if path == "/_/tenant" && req.Method == "POST" {
 		runWithErrorHandling(w, req, server, handleTenantAPI)
+*/
 	} else {
 		// Unrecognized
 		w.WriteHeader(http.StatusNotFound)


### PR DESCRIPTION
Running this code currently causes an enable-time problem that prevents snapshot from building. Until changes are made elsewhere (Okapi?) it's better to prevent it from running.