### PR TITLE
MODREP-30: Upgrade golang from 1.23 to 1.24

### DIFF
--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   go-lint:
-    uses: folio-org/.github/.github/workflows/go-lint.yml@v1
+    uses: folio-org/.github/.github/workflows/go-lint.yml@FOLIO-4287
     with:
       errcheck-excludes-file: 'src/.errcheck-exclude'
       golangci-config-file: 'src/.golangci.yml'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [1.3.2](https://github.com/folio-org/mod-reporting/tree/v1.3.2) (IN PROGRESS)
 
 * Smaller base images in Dockerfile. Fixes MODREP-24.
+* Upgrade golang from 1.23 to 1.24. Fixes MODREP-30.
 * Support validation of report URLs by reference to a whitelist of regexps in the configuration file. Fixes MODREP-4.
 
 ## [1.3.1](https://github.com/folio-org/mod-reporting/tree/v1.3.1) (2025-03-12)

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,10 @@
 # Run with: docker run -p 12369:12369 -e OKAPI_PW=[DIKU_ADMIN-PASSWORD] mod-reporting
 
 # also update the version in go.mod
-FROM golang:1.23-alpine AS build
+FROM golang:1.24-alpine AS build
+
+# Install latest patch versions of alpine packages: https://pythonspeed.com/articles/security-updates-in-docker/
+RUN apk upgrade --no-cache
 
 # Set destination for COPY
 WORKDIR /app

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/folio-org/mod-reporting
 
-go 1.23.6  // also update the version in Dockerfile
+go 1.24.2  // also update the version in Dockerfile
 
 require (
 	github.com/MikeTaylor/catlogger v0.0.2

--- a/src/.golangci.yml
+++ b/src/.golangci.yml
@@ -1,6 +1,24 @@
+version: "2"
 linters:
   enable:
-    - gofmt
     - whitespace
-output:
-  print-issued-lines: false
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODREP-30

This indirectly fixes https://pkg.go.dev/vuln/GO-2025-3563 = CVE-2025-22871 (net/http package request smuggling via bare LF line terminator) = https://github.com/advisories/GHSA-g9pc-8g42-g6vq

The build fails until https://github.com/folio-org/.github/pull/81 gets merged.