### PR TITLE
[MODREP-28] Ignore empty order-by clauses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Smaller base images in Dockerfile. Fixes MODREP-24.
 * Support validation of report URLs by reference to a whitelist of regexps in the configuration file. Fixes MODREP-4.
+* In JSON queries, ignore order-by elements when the fieldname is empty. Fixes MODREP-28.
 
 ## [1.3.1](https://github.com/folio-org/mod-reporting/tree/v1.3.1) (2025-03-12)
 

--- a/src/reporting.go
+++ b/src/reporting.go
@@ -217,8 +217,9 @@ func makeSql(query jsonQuery, session *ModReportingSession, token string) (strin
 	if filterString != "" {
 		sql += " WHERE " + filterString
 	}
-	if len(qt.Order) > 0 {
-		sql += " ORDER BY " + makeOrder(qt.Order)
+	orderString := makeOrder(qt.Order)
+	if orderString != "" {
+		sql += " ORDER BY " + orderString
 	}
 	if qt.Limit != 0 {
 		sql += fmt.Sprintf(" LIMIT %d", qt.Limit)
@@ -298,7 +299,13 @@ func validateValue(value string, column dbColumn) error {
 
 func makeOrder(orders []queryOrder) string {
 	s := ""
-	for i, order := range orders {
+	for _, order := range orders {
+		if order.Key == "" {
+			continue
+		}
+		if s != "" {
+			s += ", "
+		}
 		s += order.Key
 		s += " " + order.Direction
 		// Historically, ui-ldp sends "start" or "end"
@@ -308,9 +315,6 @@ func makeOrder(orders []queryOrder) string {
 			s += " NULLS FIRST"
 		} else {
 			s += " NULLS LAST"
-		}
-		if i < len(orders)-1 {
-			s += ", "
 		}
 	}
 

--- a/src/reporting_test.go
+++ b/src/reporting_test.go
@@ -98,6 +98,26 @@ func Test_makeSql(t *testing.T) {
 			expectedArgs: []string{},
 		},
 		{
+			name: "query with missing first order",
+			sendData: `{ "tables": [{ "schema": "folio_users", "tableName": "users",
+				"orderBy": [
+					{ "direction": "asc", "nulls": "start" },
+					{ "key": "id", "direction": "desc", "nulls": "end" }
+				] }] }`,
+			expected:     `SELECT * FROM "folio_users"."users" ORDER BY id desc NULLS LAST`,
+			expectedArgs: []string{},
+		},
+		{
+			name: "query with missing last order",
+			sendData: `{ "tables": [{ "schema": "folio_users", "tableName": "users",
+				"orderBy": [
+					{ "key": "user", "direction": "asc", "nulls": "start" },
+					{ "direction": "desc", "nulls": "end" }
+				] }] }`,
+			expected:     `SELECT * FROM "folio_users"."users" ORDER BY user asc NULLS FIRST`,
+			expectedArgs: []string{},
+		},
+		{
 			name:         "query with limit",
 			sendData:     `{ "tables": [{ "schema": "folio_users", "tableName": "users", "limit": 99 }] }`,
 			expected:     `SELECT * FROM "folio_users"."users" LIMIT 99`,


### PR DESCRIPTION
In JSON queries, ignore order-by elements when the fieldname is empty