### PR TITLE
FOLIO-4287 Use go-lint Workflow master branch

### DIFF
--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   go-lint:
-    uses: folio-org/.github/.github/workflows/go-lint.yml@FOLIO-4287
+    uses: folio-org/.github/.github/workflows/go-lint.yml@master
     with:
       errcheck-excludes-file: 'src/.errcheck-exclude'
       golangci-config-file: 'src/.golangci.yml'


### PR DESCRIPTION
The PR has been merged at folio-org/.github/pull/81 so use its master branch until a release happens.