### PR TITLE
[MODREP-35] URL-encode double quotes in CQL queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for mod-reporting
 
+## [1.4.1](https://github.com/folio-org/mod-reporting/tree/v1.4.1) (IN PROGRESS)
+
+* URL-encode double quotes to `%22` sequences in CQL queries to mod-settings. Fixes MODREP-35.
+
 ## [1.4.0](https://github.com/folio-org/mod-reporting/tree/v1.4.0) (2025-05-16)
 
 * Smaller base images in Dockerfile. Fixes MODREP-24.

--- a/src/getdbinfo.go
+++ b/src/getdbinfo.go
@@ -46,7 +46,7 @@ func getDbInfo(session foliogo.Session, token string) (string, string, string, e
 	}
 
 	params := foliogo.RequestParams{Token: token}
-	bytes, err := session.Fetch(`settings/entries?query=scope=="ui-ldp.admin"+and+key=="dbinfo"`, params)
+	bytes, err := session.Fetch("settings/entries?query=scope==%22ui-ldp.admin%22+and+key==%22dbinfo%22", params)
 	if err != nil {
 		return "", "", "", fmt.Errorf("cannot fetch 'dbinfo' from config: %w", err)
 	}

--- a/src/ldp-config.go
+++ b/src/ldp-config.go
@@ -99,7 +99,7 @@ func settingsItemToConfigItem(item settingsItemGeneral, tenant string) (configIt
 
 // The /ldp/config endpoint only supports GET, with no URL parameters
 func handleConfig(w http.ResponseWriter, req *http.Request, session *ModReportingSession) error {
-	bytes, err := fetchWithToken0(req, session.folioSession, `settings/entries?query=scope=="ui-ldp.admin"`)
+	bytes, err := fetchWithToken0(req, session.folioSession, "settings/entries?query=scope==%22ui-ldp.admin%22")
 	if err != nil {
 		return fmt.Errorf("could not fetch from mod-settings: %w", err)
 	}
@@ -146,7 +146,7 @@ func handleConfigKey(w http.ResponseWriter, req *http.Request, session *ModRepor
 	}
 
 	// Assume GET
-	path := `settings/entries?query=scope=="ui-ldp.admin"+and+key=="` + key + `"`
+	path := "settings/entries?query=scope==%22ui-ldp.admin%22+and+key==%22" + key + "%22"
 	bytes, err = fetchWithToken0(req, session.folioSession, path)
 	if err != nil {
 		return fmt.Errorf("could not read from mod-settings: %w", err)
@@ -196,7 +196,7 @@ func writeConfigKey(w http.ResponseWriter, req *http.Request, session *ModReport
 	// we're creating a new key from if we're replacing an
 	// existing one, so we need first to search for an existing
 	// record
-	path := `settings/entries?query=scope=="ui-ldp.admin"+and+key=="` + key + `"`
+	path := "settings/entries?query=scope==%22ui-ldp.admin%22+and+key==%22" + key + "%22"
 	bytes, err = fetchWithToken0(req, session.folioSession, path)
 	if err != nil {
 		return fmt.Errorf("could not read from mod-settings: %w", err)

--- a/src/testhelper_test.go
+++ b/src/testhelper_test.go
@@ -48,7 +48,7 @@ type testT struct {
 func MakeMockHTTPServer() *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		if req.URL.Path == "/settings/entries" &&
-			req.URL.RawQuery == `query=scope=="ui-ldp.admin"` {
+			req.URL.RawQuery == "query=scope==%22ui-ldp.admin%22" {
 			_, _ = w.Write([]byte(`
 			  {
 			    "items": [
@@ -66,7 +66,7 @@ func MakeMockHTTPServer() *httptest.Server {
 			  }
 			`))
 		} else if req.URL.Path == "/settings/entries" &&
-			req.URL.RawQuery == `query=scope=="ui-ldp.admin"+and+key=="dbinfo"` {
+			req.URL.RawQuery == "query=scope==%22ui-ldp.admin%22+and+key==%22dbinfo%22" {
 			// XXX note that this specific value is also required by the getDbInfo test
 			_, _ = w.Write([]byte(`
 			  {
@@ -89,7 +89,7 @@ func MakeMockHTTPServer() *httptest.Server {
 			  }
 			`))
 		} else if req.URL.Path == "/settings/entries" &&
-			req.URL.RawQuery == `query=scope=="ui-ldp.admin"+and+key=="non-string"` {
+			req.URL.RawQuery == "query=scope==%22ui-ldp.admin%22+and+key==%22non-string%22" {
 			_, _ = w.Write([]byte(`
 			  {
 			    "items": [
@@ -107,7 +107,7 @@ func MakeMockHTTPServer() *httptest.Server {
 			  }
 			`))
 		} else if req.URL.Path == "/settings/entries" &&
-			req.URL.RawQuery == `query=scope=="ui-ldp.admin"+and+key=="bad"` {
+			req.URL.RawQuery == "query=scope==%22ui-ldp.admin%22+and+key==%22bad%22" {
 			_, _ = w.Write([]byte("some bit of text"))
 		} else if req.URL.Path == "/settings/entries" {
 			// Searching for some other setting, e.g. "score" before trying to write to it


### PR DESCRIPTION
RFC 3986 does not include double quotes among the "unreserved characters" that can be used in URLs. Accordingly, strict software is at liberty to complain about URLs that include them, and Eureka's Okapi-replacement software does this. We were previously using literal double quotes in CQL queries to mod-settings: we now escape these by URL-encoding them to `%22`.

Should unblock EUREKASUP-72.