### PR TITLE
[MODREP-37] Do not check for errors writing HTTP repsonses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for mod-reporting
 
+## IN PROGRESS
+
+* When writing an HTTP response fails, do not attempt to inform the client by writing the HTTP response again. Avoids "superfluous response.WriteHeader call" warning. Fixes MODREP-37.
+
 ## [1.4.1](https://github.com/folio-org/mod-reporting/tree/v1.4.1) (2025-06-03)
 
 * URL-encode double quotes to `%22` sequences in CQL queries to mod-settings. Fixes MODREP-35.

--- a/src/ldp-config.go
+++ b/src/ldp-config.go
@@ -243,6 +243,6 @@ func writeConfigKey(w http.ResponseWriter, req *http.Request, session *ModReport
 	if err != nil {
 		return fmt.Errorf("could not serialize JSON for response: %w", err)
 	}
-	_, err = w.Write(bytes)
-	return err
+	_, _ = w.Write(bytes)
+	return nil
 }

--- a/src/reporting.go
+++ b/src/reporting.go
@@ -631,6 +631,8 @@ func sendJSON(w http.ResponseWriter, data any, caption string) error {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	_, err = w.Write(bytes)
-	return err
+
+	// If w.write fails there is no way to report this to the client: see MODREP-37.
+	_, _ = w.Write(bytes)
+	return nil
 }


### PR DESCRIPTION
When writing an HTTP response fails, do not attempt to inform the client by writing the HTTP response again. There is no way to do so (the connection back to the client is not working due to a timeout or other error, so there is no point trying to write more to it).

Avoids "superfluous response.WriteHeader call" warning.